### PR TITLE
Makefile: Assign OUTROOT using `?=`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ DEBUG ?= chk
 CURDIR := $(subst \,/,$(CURDIR))
 SRCROOT ?= $(CURDIR)
 SRCROOT := $(subst \,/,$(SRCROOT))
-OUTROOT := $(SRCROOT)/out
+OUTROOT ?= $(SRCROOT)/out
 
 VPATH := $(SRCROOT)
 


### PR DESCRIPTION
To be able to use environment variable.
Use a different dir for x64 build?

There are still errors for Windows:
```
rtl/base/x64/rtlarch.S:64: Error: unknown pseudo-op: `.hidden'
rtl/base/x64/rtlarch.S:64: Warning: .type pseudo-op used outside of .def/.endef: ignored.
rtl/base/x64/rtlarch.S:64: Error: junk at end of line, first unrecognized character is `R'
```
Got:
https://github.com/minoca/swiss/blob/ff1fc5dd406abeeceaa91e4e3cf5a9b64824fb3f/include/minoca/kernel/x64.inc#L114-L115
compared with
https://github.com/minoca/swiss/blob/ff1fc5dd406abeeceaa91e4e3cf5a9b64824fb3f/include/minoca/kernel/x86.inc#L173
I'm not familiar with ASM.
Seems `.hidden' is only for ELF, and not adapted for Windows yet.

Ref: https://sourceware.org/binutils/docs/as/Hidden.html